### PR TITLE
[install] Remove errant `s` from `set` if it exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -211,6 +211,8 @@ download() {
   _url="$1"
   _dst="$2"
 
+  need_cmd sed
+
   # Attempt to download with wget, if found. If successful, quick return
   if command -v wget >/dev/null; then
     info "Downloading $_url to $_dst (wget)"
@@ -218,7 +220,7 @@ download() {
     set +e
     wget -q -O "$_dst" "$_url"
     _code="$?"
-    set "-$_orig_flags"
+    set "-$(echo "$_orig_flags" | sed s/s//g)"
     if [ $_code -eq 0 ]; then
       unset _url _dst _code _orig_flags
       return 0
@@ -238,7 +240,7 @@ download() {
     set +e
     curl -sSfL "$_url" -o "$_dst"
     code="$?"
-    set "-$_orig_flags"
+    set "-$(echo "$_orig_flags" | sed s/s//g)"
     if [ $code -eq 0 ]; then
       unset _url _dst _code _orig_flags
       return 0


### PR DESCRIPTION
This situation was discovered when running the `install.sh` program via
a "curl/sh" invocation such as:

```console
$ curl --proto '=https' --tlsv1.2 -sSf \
    https://raw.githubusercontent.com/fnichol/libsh/master/install.sh \
  | sh -s -- --mode=vendor
```

In this case, an `s` was inserted in `$-` causing an error such as `set:
-s: invalid option` when calling the `download` function.

This change strips out any `s` characters before restoring the original
set flags.

Note that it is hypothesized that using `sh -s --` is causing this
behavior (directly invoking the script or not providing any arguments to
the piped `sh` work fine). It is not conclusive and therefore a little
troubling to have found this issue.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>