### PR TITLE
Update `die` to exit & introduce `check_cmd`

### DIFF
--- a/tests/libsh_test.sh
+++ b/tests/libsh_test.sh
@@ -14,6 +14,23 @@ setUp() {
   commonSetUp
 }
 
+testCheckCmdPresent() {
+  # The `ls` command should almost always be in `$PATH` as a program
+  run check_cmd ls
+
+  assertTrue 'check_cmd failed' "$return_status"
+  assertStdoutNull
+  assertStderrNull
+}
+
+testCheckCmdMissing() {
+  run check_cmd __not_a_great_chance_this_will_exist__
+
+  assertFalse 'check_cmd succeeded' "$return_status"
+  assertStdoutNull
+  assertStderrNull
+}
+
 testCleanupFile() {
   local file
   __CLEANUP_FILES__="$(mktemp_file)"
@@ -48,7 +65,7 @@ testCleanupFileNoVar() {
 
 testDieStripAnsi() {
   printf -- '\nxxx I give up\n\n' >"$expected"
-  run die 'I give up'
+  run_in_sh_script die 'I give up'
 
   stripAnsi <"$stderr" >"$actual"
 
@@ -62,7 +79,7 @@ testDieStripAnsi() {
 testDieAnsi() {
   printf -- '\n\033[1;31;40mxxx \033[1;37;40mI give up\033[0m\n\n' >"$expected"
   export TERM=xterm
-  run die 'I give up'
+  run_in_sh_script die 'I give up'
 
   assertFalse 'fail did not fail' "$return_status"
   # Shell string equals has issues with ANSI escapes, so let's use `cmp` to
@@ -111,7 +128,7 @@ testNeedCmdPresent() {
 }
 
 testNeedCmdMissing() {
-  run need_cmd __not_a_great_chance_this_will_exist__
+  run_in_sh_script need_cmd __not_a_great_chance_this_will_exist__
 
   assertFalse 'need_cmd succeeded' "$return_status"
   assertStderrStripAnsiContains 'xxx Required command'

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -137,7 +137,7 @@ run() {
 }
 
 run_in_sh_script() {
-  cat "${0%/*}/../libsh.sh" >"$tmppath/sh_script.sh"
+  cat "$libsh_src" >"$tmppath/sh_script.sh"
   echo >>"$tmppath/sh_script.sh"
   echo '"$@"' >>"$tmppath/sh_script.sh"
 
@@ -166,6 +166,8 @@ shell_compat() {
     SHUNIT_PARENT="$1"
   fi
 }
+
+libsh_src="${0%/*}/../libsh.sh"
 
 # shellcheck disable=SC2034
 shunit2="${0%/*}/../tmp/shunit2/shunit2"


### PR DESCRIPTION
This changeset was spurred by a realization that a shell function which
returns a non-zero exit code will **not** exit the program or script
currently running, despite whether or not `set -e` is enabled. As `die`
in its name implies that the process should abort/terminate, an `exit 1`
is not used to replace the prior behavior of `return 1`.

So, `die` will no longer return from its function but rather terminate
the running shell process. Note that this should be a script but if
`die` is invoked in an interactive shell session, then the shell will
quit.

Given this update, the behavior of `need_cmd` also changed as a result
of using `die` under the hood. As a consequence, `need_cmd` will also no
longer return from its function if the given program could not be found
on `PATH`.

Finally as a result of all of the above, it seemed useful to have
another function that would only *check* for a program but not terminate
the script. Hence, `check_cmd` was introduced to return either `0` on
success or `1` on failure. The implementation of `need_cmd` was updated
to call `check_cmd` and `die` is still used for `need_cmd`.

Note that this is a **breaking change** for the following functions:

* `die`: will quit the running shell and not return
* `need_cmd`: will quit the running shell and not return if the program
  cannot be found

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>