### PR TITLE
fix: ensure file/directory cleanups only apply to current process

### DIFF
--- a/API.md
+++ b/API.md
@@ -490,6 +490,8 @@ This function is typically used in combination with [`cleanup_directory`] and
 - `__CLEANUP_DIRECTORIES__` used to track the collection of directories to clean
   up whose value is a file. If not declared or set, this function will set it
   up.
+- `__CLEANUP_DIRECTORIES_SETUP__` used to track if the `__CLEANUP_DIRECTORIES__`
+  variable has been set up for the current process
 
 ### Examples
 
@@ -529,6 +531,8 @@ This function is typically used in combination with [`cleanup_file`] and
 
 - `__CLEANUP_FILES__` used to track the collection of files to clean up whose
   value is a file. If not declared or set, this function will set it up.
+- `__CLEANUP_FILES_SETUP__` used to track if the `__CLEANUP_FILES__` variable
+  has been set up for the current process
 
 ### Examples
 

--- a/lib/setup_cleanup_directories.sh
+++ b/lib/setup_cleanup_directories.sh
@@ -15,6 +15,8 @@
 # * `__CLEANUP_DIRECTORIES__` used to track the collection of directories to
 # clean up whose value is a file. If not declared or set, this function will
 # set it up.
+# * `__CLEANUP_DIRECTORIES_SETUP__` used to track if the
+# `__CLEANUP_DIRECTORIES__` variable has been set up for the current process
 #
 # # Examples
 #
@@ -40,6 +42,12 @@
 # [`setup_traps`]: #setup_traps
 # [`trap_cleanup_directories`]: #trap_cleanup_directories
 setup_cleanup_directories() {
+  if [ "${__CLEANUP_DIRECTORIES_SETUP__:-}" != "$$" ]; then
+    unset __CLEANUP_DIRECTORIES__
+    __CLEANUP_DIRECTORIES_SETUP__="$$"
+    export __CLEANUP_DIRECTORIES_SETUP__
+  fi
+
   # If a tempfile hasn't been setup yet, create it
   if [ -z "${__CLEANUP_DIRECTORIES__:-}" ]; then
     __CLEANUP_DIRECTORIES__="$(mktemp_file)"

--- a/lib/setup_cleanup_files.sh
+++ b/lib/setup_cleanup_files.sh
@@ -14,6 +14,8 @@
 #
 # * `__CLEANUP_FILES__` used to track the collection of files to clean up whose
 #   value is a file. If not declared or set, this function will set it up.
+# * `__CLEANUP_FILES_SETUP__` used to track if the `__CLEANUP_FILES__`
+# variable has been set up for the current process
 #
 # # Examples
 #
@@ -38,6 +40,12 @@
 # [`setup_traps`]: #setup_traps
 # [`trap_cleanup_files`]: #trap_cleanup_files
 setup_cleanup_files() {
+  if [ "${__CLEANUP_FILES_SETUP__:-}" != "$$" ]; then
+    unset __CLEANUP_FILES__
+    __CLEANUP_FILES_SETUP__="$$"
+    export __CLEANUP_FILES_SETUP__
+  fi
+
   # If a tempfile hasn't been setup yet, create it
   if [ -z "${__CLEANUP_FILES__:-}" ]; then
     __CLEANUP_FILES__="$(mktemp_file)"


### PR DESCRIPTION
This change fixes an issue where a sub-process or calling script which
also uses libsh will potentially clean up all files and/or directories
of the parent when the child's trap handlers fire. This is not expected
behavior--each process should essentially have its own record of files
and directories for clean up.

In order to ensure this happens, 2 new global variables are used and
tracked in `setup_cleanup_files` and `setup_cleanup_directories`:
`__CLEANUP_FILES_SETUP__` and `__CLEANUP_DIRECTORIES_SETUP__`
respectively.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>