### PR TITLE
Add download option with fetch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ test_task:
           - SHELL_BIN: zsh
             PKG: shells/zsh
       freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-14-0
       setup_script: |
         pkg install --yes devel/git devel/gmake textproc/gsed
         if [ -n "${PKG:-}" ]; then pkg install --yes "$PKG"; fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ test_task:
           - SHELL_BIN: ksh
           - SHELL_BIN: zsh
       macos_instance:
-        image: catalina-base
+        image: ghcr.io/cirruslabs/macos-sonoma-base:latest
       setup_script: |
         if [ -n "${PKG:-}" ]; then brew install "$PKG"; fi
         if [ "$SHELL_BIN" = "bash-3" ]; then


### PR DESCRIPTION
In base FreeBSD system there is a same alike took like curl, ftp etc. called fetch. The FreeBSD base system does not install any third party applications so bootstrapping a system without the support of fetch is often cumbersome. With this option added the download function also checks for fetch in case none of the third party applications like curl, wget are available for a freshly installed system.